### PR TITLE
Fix LuaBuffer constructor

### DIFF
--- a/nativetext/src/extension.cpp
+++ b/nativetext/src/extension.cpp
@@ -41,7 +41,7 @@ static void push_image_resource(lua_State *L, int width, int height, dmBuffer::H
 	lua_setfield(L, -2, "header");
 
 	if (buffer != 0) {
-		dmScript::LuaHBuffer lua_buffer = {buffer, true};
+		dmScript::LuaHBuffer lua_buffer(buffer, dmScript::OWNER_LUA);
 		dmScript::PushBuffer(L, lua_buffer);
 		lua_setfield(L, -2, "buffer");
 	}


### PR DESCRIPTION
I fixed the following build error: 
<img width="600" alt="スクリーンショット 2023-12-15 2 38 36" src="https://github.com/Lerg/extension-nativetext/assets/832498/df7b51e7-f7e7-4faf-aa8c-eb2cbca1682c">
Defold version: 1.6.2

Thank you for creating such a great extension 😃 